### PR TITLE
Use  acme4j version 2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,13 +47,13 @@
 		<dependency>
 		  <groupId>org.shredzone.acme4j</groupId>
 		  <artifactId>acme4j-client</artifactId>
-		  <version>0.14</version>
+		  <version>2.8</version>
 		</dependency>
 		
 		<dependency>
 		  <groupId>org.shredzone.acme4j</groupId>
 		  <artifactId>acme4j-utils</artifactId>
-		  <version>0.14</version>
+		  <version>2.8</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/creactiviti/spring/boot/starter/acme/CertGenerator.java
+++ b/src/main/java/com/creactiviti/spring/boot/starter/acme/CertGenerator.java
@@ -9,27 +9,24 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URI;
 import java.security.KeyPair;
-import java.security.cert.X509Certificate;
 import java.util.Arrays;
 
 import org.apache.commons.io.IOUtils;
+import org.shredzone.acme4j.Account;
+import org.shredzone.acme4j.AccountBuilder;
 import org.shredzone.acme4j.Authorization;
 import org.shredzone.acme4j.Certificate;
-import org.shredzone.acme4j.Registration;
-import org.shredzone.acme4j.RegistrationBuilder;
+import org.shredzone.acme4j.Order;
 import org.shredzone.acme4j.Session;
 import org.shredzone.acme4j.Status;
 import org.shredzone.acme4j.challenge.Challenge;
 import org.shredzone.acme4j.challenge.Http01Challenge;
-import org.shredzone.acme4j.exception.AcmeConflictException;
 import org.shredzone.acme4j.exception.AcmeException;
 import org.shredzone.acme4j.util.CSRBuilder;
-import org.shredzone.acme4j.util.CertificateUtils;
 import org.shredzone.acme4j.util.KeyPairUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.util.Assert;
 
 /**
  * @author Arik Cohen
@@ -52,7 +49,7 @@ public class CertGenerator {
   }
 
   /**
-   * Generates a certificate for the given domain. Also takes care of the registration
+   * Generates a certificate for the given domain. Also takes care of the registration 
    * process.
    *
    * @param aDomain
@@ -65,13 +62,19 @@ public class CertGenerator {
     KeyPair userKeyPair = loadOrCreateKeyPair(new File(config.getUserKeyFile()));
 
     // Create a session for Let's Encrypt.
-    Session session = new Session(config.getEndpoint(), userKeyPair);
+    Session session = new Session(config.getEndpoint());
 
-    // Get the Registration to the account.
+    // Get the Account.
     // If there is no account yet, create a new one.
-    Registration reg = getOrCreateAccount(session);
+    Account acct = findOrRegisterAccount(session, userKeyPair);
 
-    authorize(reg, aDomain);
+    // Order the certificate
+    Order order = acct.newOrder().domains(aDomain).create();
+
+    // Perform all required authorizations
+    for (Authorization auth : order.getAuthorizations()) {
+      authorize(auth);
+    }
 
     // Load or create a key pair for the domains. This should not be the userKeyPair!
     KeyPair domainKeyPair = loadOrCreateKeyPair(new File(config.getDomainKeyFile()));
@@ -86,19 +89,38 @@ public class CertGenerator {
       csrb.write(out);
     }
 
-    // Now request a signed certificate.
-    Certificate certificate = reg.requestCertificate(csrb.getEncoded());
+    // Order the certificate
+    order.execute(csrb.getEncoded());
+
+    // Wait for the order to complete
+    try {
+      int attempts = 10;
+      while (order.getStatus() != Status.VALID && attempts-- > 0) {
+        // Did the order fail?
+        if (order.getStatus() == Status.INVALID) {
+          throw new AcmeException("Order failed... Giving up.");
+        }
+
+        // Wait for a few seconds
+        Thread.sleep(3000L);
+
+        // Then update the status
+        order.update();
+      }
+    } catch (InterruptedException ex) {
+      logger.error("interrupted", ex);
+      Thread.currentThread().interrupt();
+    }
+
+    // Get the certificate
+    Certificate certificate = order.getCertificate();
 
     logger.info("Success! The certificate for domain {} has been generated!", aDomain);
     logger.info("Certificate URL: {}", certificate.getLocation());
 
-    // Download the leaf certificate and certificate chain.
-    X509Certificate cert = certificate.download();
-    X509Certificate[] chain = certificate.downloadChain();
-
     // Write a combined file containing the certificate and chain.
     try (FileWriter fw = new FileWriter(new File (config.getDomainChainFile()))) {
-      CertificateUtils.writeX509CertificateChain(fw, cert, chain);
+      certificate.writeCertificate(fw);
     }
 
     // convert the certificate format to PKS
@@ -107,12 +129,12 @@ public class CertGenerator {
 
     Process process = pbuilder.start();
     int errCode = process.waitFor();
-    
+
     try(InputStream in = process.getInputStream(); StringWriter writer = new StringWriter()) {
       IOUtils.copy(in, writer, "ASCII");
       logger.debug("openssl finished with exit code {} \n{}",errCode, writer.toString());
     }
-    
+
   }
 
   /**
@@ -136,63 +158,50 @@ public class CertGenerator {
   }
 
   /**
-   * Finds your {@link Registration} at the ACME server. It will be found by your user's
-   * public key. If your key is not known to the server yet, a new registration will be
+   * Finds your {@link Account} at the ACME server. It will be found by your user's
+   * public key. If your key is not known to the server yet, a new account will be
    * created.
-   * <p>
-   * This is a simple way of finding your {@link Registration}. A better way is to get
-   * the URL of your new registration with {@link Registration#getLocation()} and store
-   * it somewhere. If you need to get access to your account later, reconnect to it via
-   * {@link Registration#bind(Session, URL)} by using the stored location.
    *
-   * @param session
-   *            {@link Session} to bind with
-   * @return {@link Registration} connected to your account
+   * @param session {@link Session} to bind with
+   * @return {@link Account} that is connected to your account
    */
-  private Registration getOrCreateAccount(Session session) throws AcmeException {
-
-    Registration reg;
-
-    try {
-      // Try to create a new Registration.
-      reg = new RegistrationBuilder().create(session);
-      logger.info("Registered a new user, URL: " + reg.getLocation());
-
-      // This is a new account. Let the user accept the Terms of Service.
-      // We won't be able to authorize domains until the ToS is accepted.
-      URI agreement = reg.getAgreement();
-      logger.info("Terms of Service: " + agreement);
-      acceptAgreement(reg, agreement);
-
-    } catch (AcmeConflictException ex) {
-      // The Key Pair is already registered. getLocation() contains the
-      // URL of the existing registration's location. Bind it to the session.
-      reg = Registration.bind(session, ex.getLocation());
-      logger.info("Account does already exist, URL: " + reg.getLocation(), ex);
+  private Account findOrRegisterAccount(Session session, KeyPair accountKey) throws AcmeException {
+    // Ask the user to accept the TOS, if server provides us with a link.
+    URI tos = session.getMetadata().getTermsOfService();
+    if (tos != null) {
+      acceptAgreement(tos);
     }
 
-    return reg;
+    Account account = new AccountBuilder()
+        .agreeToTermsOfService()
+        .useKeyPair(accountKey)
+        .create(session);
+    logger.info("Registered a new user, URL: {}", account.getLocation());
+
+    return account;
   }
 
   /**
    * Authorize a domain. It will be associated with your account, so you will be able to
    * retrieve a signed certificate for the domain later.
-   * <p>
-   * You need separate authorizations for subdomains (e.g. "www" subdomain). Wildcard
-   * certificates are currently not supported.
    *
-   * @param aRegistration
-   *            {@link Registration} of your account
-   * @param aDomain
-   *            Name of the domain to authorize
+   * @param auth
+   *            {@link Authorization} to perform
    */
-  private void authorize (Registration aRegistration, String aDomain) throws AcmeException {
-    // Authorize the domain.
-    Authorization auth = aRegistration.authorizeDomain(aDomain);
-    logger.info("Authorization for domain " + aDomain);
+  private void authorize(Authorization auth) throws AcmeException {
+    logger.info("Authorization for domain {}", auth.getIdentifier().getDomain());
+
+    // The authorization is already valid. No need to process a challenge.
+    if (auth.getStatus() == Status.VALID) {
+      return;
+    }
 
     // Find the desired challenge and prepare it.
-    Challenge challenge = httpChallenge(auth, aDomain);
+    Challenge challenge = httpChallenge(auth);
+
+    if (challenge == null) {
+      throw new AcmeException("No challenge found");
+    }
 
     // If the challenge is already verified, there's no need to execute it again.
     if (challenge.getStatus() == Status.VALID) {
@@ -219,13 +228,17 @@ public class CertGenerator {
       }
     } catch (InterruptedException ex) {
       logger.error("interrupted", ex);
+      Thread.currentThread().interrupt();
     }
 
     // All reattempts are used up and there is still no valid authorization?
     if (challenge.getStatus() != Status.VALID) {
-      throw new AcmeException("Failed to pass the challenge for domain " + aDomain + ", ... Giving up.");
+      throw new AcmeException("Failed to pass the challenge for domain "
+          + auth.getIdentifier().getDomain() + ", ... Giving up.");
     }
-    
+
+    logger.info("Challenge has been completed. Remember to remove the validation resource.");
+//    completeChallenge("Challenge has been completed.\nYou can remove the resource again now.");
   }
 
   /**
@@ -237,28 +250,25 @@ public class CertGenerator {
    *
    * @param aAuthorization
    *            {@link Authorization} to find the challenge in
-   * @param aDomainName
-   *            Domain name to be authorized
    * @return {@link Challenge} to verify
    */
-  private Challenge httpChallenge(Authorization aAuthorization, String aDomainName) throws AcmeException {
+  private Challenge httpChallenge(Authorization aAuthorization) throws AcmeException {
     // Find a single http-01 challenge
     Http01Challenge challenge = aAuthorization.findChallenge(Http01Challenge.TYPE);
-    
+
     if (challenge == null) {
       throw new AcmeException("Found no " + Http01Challenge.TYPE + " challenge, don't know what to do...");
     }
-    
+
     challengeStore.put(challenge.getToken(), challenge.getAuthorization());
 
     return challenge;
   }
 
-  private void acceptAgreement(Registration aRegistration, URI aAgreement) throws AcmeException {
-    Assert.isTrue(config.isAcceptTermsOfService(),"You must accept the TOS: " + aAgreement + " by setting the property acme.accept-terms-of-service to true");
-    // Motify the Registration and accept the agreement
-    aRegistration.modify().setAgreement(aAgreement).commit();
-    logger.info("Updated user's ToS");
+  private void acceptAgreement(URI agreement) throws AcmeException {
+    if (!config.isAcceptTermsOfService()){
+      throw new AcmeException("User did not accept Terms of Service");
+    }
   }
-
+  
 }


### PR DESCRIPTION
Currently spring-boot-starter-acme uses acme4j version 0.14, which supports ACMEv1 only.
It worked fine until `letsencrypt` stopped support ACMEv1 as described in https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430

This pull request is about migration to acme4j version 2.8
